### PR TITLE
Fixed minor typos

### DIFF
--- a/software/haddock2.2/run.html
+++ b/software/haddock2.2/run.html
@@ -65,7 +65,7 @@ should be set automatically by HADDOCK from the number defined in
 </UL>
 <hr>
 <BR>
-<a name="names"><b>2. <u>Filenames</u></b></a> <a href="/software/haddock2.2/filenames.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="names"><b>2. <u>Filenames</u></b></a> <a href="/software/haddock2.2/filenames.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 This section consist of all the files that will be used for the docking. 
 If the <i><b>new.html</b></i> file has been set up properly, most fields will be set correctly.
@@ -86,7 +86,7 @@ Also check that the HADDOCK directory, defining the path to the HADDOCK programs
 </ul>
 <hr>
 <BR>
-<a name="histidines"><b>3. <u>Definition of the protonation state of histidines</u></b></a> <a href="/software/haddock2.2/histidines.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="histidines"><b>3. <u>Definition of the protonation state of histidines</u></b></a> <a href="/software/haddock2.2/histidines.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 By default, all histidines are protonated and thus carry a net positive charge. In this
 section you can specify the protonation state of histidines for each protein. A neutral
@@ -104,7 +104,7 @@ choices were made for the protonation state of the various histidines. For this 
 <BR>
 <hr>
 <BR>
-<a name="interface"><b>4. <u>Definition of the semi-flexible interface</u></b></a> <a href="/software/haddock2.2/interface.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="interface"><b>4. <u>Definition of the semi-flexible interface</u></b></a> <a href="/software/haddock2.2/interface.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 HADDOCK performs a semi-flexible simulated annealing (SA). Here you have to 
 define the residues that will be allowed to move during the SA. 
@@ -137,7 +137,7 @@ be defined automatically.
 <BR>
 <hr>
 <BR>
-<a name="flex"><b>5. <u>Definition of fully flexible segments</u></b></a> <a href="/software/haddock2.2/flexible.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="flex"><b>5. <u>Definition of fully flexible segments</u></b></a> <a href="/software/haddock2.2/flexible.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 HADDOCK allows the definition of fully flexible segments for each molecule. 
 These will be fully flexible throughout the entire docking protocol except for the rigid body minimization
@@ -160,7 +160,7 @@ This section allows to define two types of restraints to enforce symmetry either
     <li> C2, C3, S3, C4 and C5 symmetry restraints
 </ul> 
 <BR>
-<u><i>Non-crystallographic symmetry restraints (NCS)</i></u> <a href="/software/haddock2.2/ncs.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<u><i>Non-crystallographic symmetry restraints (NCS)</i></u> <a href="/software/haddock2.2/ncs.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 The NCS option imposes non-crystallographic symmetry restraints: it enforces that two molecules, a fraction thereof or even two sub-domains within the same molecule should be identical without defining any symmetry operation between them.
 <BR><BR>
@@ -171,7 +171,7 @@ HADDOCK 2.X allows to define up to five pairs for which NCS restraints will be a
                 pairs contain exactly the same number of atoms.
 </ul>
 <BR>
-<u><i>C2, C3, S3, C4 and C5 symmetry restraints</i></u> <a href="/software/haddock2.2/symmetry.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<u><i>C2, C3, S3, C4 and C5 symmetry restraints</i></u> <a href="/software/haddock2.2/symmetry.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 HADDOCK 2.X offers the possibility to define multiple symmetry relationships within or in between molecules. This is done by using symmetry distance restraints (Nilges 1993). Symmetry distance restraints are a special class in CNS:
 for each restraint two distances are specified which are required to remain equal during the calculations, irrespective
@@ -212,7 +212,7 @@ done in the <i>symmultimer.cns</i> CNS script). Currently
 </ul>
 <hr>
 <BR>
-<a name="disre"><b>7. <u>Distance restraints</u></b></a> <a href="/software/haddock2.2/distances.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="disre"><b>7. <u>Distance restraints</u></b></a> <a href="/software/haddock2.2/distances.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 <u><i>Ambiguous (AIRs) and unambigous distance restraints</i></u><BR><BR>
 Ambiguous (AIRs) and unambigous distance restraints specified in <i>new.html</i> will always be read. 
@@ -291,7 +291,7 @@ file in a web browser. You will have to edit the file manually for this.
 </ul>
 <hr>
 <BR>
-<a name="rgre"><b>8. <u>Radius of gyration restraint</u></b></a> <a href="/software/haddock2.2/rg.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="rgre"><b>8. <u>Radius of gyration restraint</u></b></a> <a href="/software/haddock2.2/rg.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 A radius of gyration distance restraint can be turned on here. It will be active throughout the entire protocol,
 but can be effectively turned off by setting the force constant for a given stage to 0. The radius of gyration should be entered in angstrom. By default it is applied to the entire system, but can be restricted to part of the system using standard CNS atom selections.
@@ -309,7 +309,7 @@ define base-pair, backbone dihedral angle and sugar pucker restraints.
 <BR>
 <hr>
 <BR>
-<a name="dihre"><b>10. <u>Dihedrals</u></b></a> <a href="/software/haddock2.2/dihedrals.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="dihre"><b>10. <u>Dihedrals</u></b></a> <a href="/software/haddock2.2/dihedrals.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 If dihedral angle restraints have been defined in the <b>new.html</b> file, 
 turn the flag <b>"use"</b> to true and specify the force constants for the 
@@ -328,7 +328,7 @@ show up in a browser window.
 <BR>
 <hr>
 <BR>
-<a name="dipo"><b>12. <u>Residual Dipolar couplings</u></b></a> <a href="/software/haddock2.2/RDCs.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="dipo"><b>12. <u>Residual Dipolar couplings</u></b></a> <a href="/software/haddock2.2/RDCs.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 If RDC data are available and have been defined in the <b>new.html</b> file, 
 you can define them in this section. Five classes are supported. For each class you
@@ -366,7 +366,7 @@ For more information on using RDC as restraints for docking see also the
 <BR>
 <hr>
 <BR>
-<a name="pcs"><b>13. <u>Pseudo contact shifts</u></b></a> <a href="/software/haddock2.2/pcs.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="pcs"><b>13. <u>Pseudo contact shifts</u></b></a> <a href="/software/haddock2.2/pcs.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 If pseudo contact shift data are available and have been defined in the <b>new.html</b> file, 
 you can define them in this section. Ten classes are supported. For each class you
@@ -393,7 +393,7 @@ Refer to the following publication for details of the implementation in HADDOCK:
 </ul>
 <hr>
 <BR>
-<a name="dani"><b>14. <u>Diffusion anisotropy restraints</u></b></a> <a href="/software/haddock2.2/DANI.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="dani"><b>14. <u>Diffusion anisotropy restraints</u></b></a> <a href="/software/haddock2.2/DANI.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 If <a href="/software/haddock2.2/DANI_help">diffusion anisotropy restraints (DANI)</a> (from <sup>15</sup>N relaxation measurements) 
 are available and have been defined in the <b>new.html</b> file, you can define them in this section. Five classes 
@@ -421,7 +421,7 @@ in HADDOCK is described in <A HREF="http://dx.doi.org/doi:10.1007/s10858-006-002
 <BR>
 <hr>
 <BR>
-<a name="topo"><b>15. <u>Topology and parameters files</u></b></a> <a href="/software/haddock2.2/topology.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="topo"><b>15. <u>Topology and parameters files</u></b></a> <a href="/software/haddock2.2/topology.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 In this section the topology, linkage and parameter files are specified for each molecule.
 The default values are for proteins using the improved parameters of 
@@ -455,7 +455,7 @@ and ZN<sup>+2</sup>. If your system contains other ions add them to the <i>coval
 <BR>
 <hr>
 <BR>
-<a name="param"><b>16. <u>Energy and interaction parameters</u></b></a> <a href="/software/haddock2.2/energy.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="param"><b>16. <u>Energy and interaction parameters</u></b></a> <a href="/software/haddock2.2/energy.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 You can define in this section a number of parameters that control the electrostatic energy term 
 during the docking process, that allow you to scale down the intermolecular interactions and sample 180 degrees rotated
@@ -491,7 +491,7 @@ These scaling factors only affect the intermolecular van der Waals and electrost
                 of a protein. A value of 0.01 should already be sufficient for this.
 </ul>
 <BR>
-<u><i>Interaction matrix for non-bonded interactions</i></u><a href="/software/haddock2.2/interaction-matrix.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a><BR><BR>
+<u><i>Interaction matrix for non-bonded interactions</i></u><a href="/software/haddock2.2/interaction-matrix.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a><BR><BR>
 This is a new feature in HADDOCK2.2 which allows to scale down or turn off interactions between specific molecules. 
 It is useful for example in the context of ensemble-averaged docking where the distance restraints should be averaged over multiple binding poses.
 This option has been applied for example in ensemble-averaged docking of a peptide using PRE-derived distance restaints. See:
@@ -503,7 +503,7 @@ E. Escobar-Cabrera, Okon, D.K.W. Lau, C.F. Dart, A.M.J.J. Bonvin and L.P. McInto
 </ul>
 <hr>
 <BR>
-<a name="numstruc"><b>17. <u>Number of structures to dock</u></b></a> <a href="/software/haddock2.2/numstruc.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="numstruc"><b>17. <u>Number of structures to dock</u></b></a> <a href="/software/haddock2.2/numstruc.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 The docking process is performed in three distinct steps:
 <ol>
@@ -537,7 +537,7 @@ effective number of structures.
 </ul>
 <hr>
 <BR>
-<a name="dock"><b>18. <u>DOCKING protocol</u></b></a> <a href="/software/haddock2.2/docking.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="dock"><b>18. <u>DOCKING protocol</u></b></a> <a href="/software/haddock2.2/docking.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 Here you can define parameters for the <a href="/software/haddock2.2/docking#mini">rigid-body</a> docking step (it0) if you want to:
 <ul>
@@ -564,7 +564,7 @@ section).
 </ul>
 <hr>
 <BR>
-<a name="solvdock"><b>19. <u>Solvated docking</u></b></a> <a href="/software/haddock2.2/solvdock.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="solvdock"><b>19. <u>Solvated docking</u></b></a> <a href="/software/haddock2.2/solvdock.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 In this section you can turn on solvated docking. If turned on, the initial structures will first be solvated in a shell of TIP3P water (only water molecules within 5.5 A of the protein will be kept). The rigid-body docking will thus be performed from solvated proteins. Two methods for dealing with interfacial waters are implemented:
 <BR>
@@ -634,7 +634,7 @@ It is also possible to turn off <b>water translation</b> during rigid-body energ
 <BR>
 <hr>
 <BR>
-<a name="water"><b>20. <u>Final explicit solvent refinement</u></b></a> <a href="/software/haddock2.2/waterref.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="water"><b>20. <u>Final explicit solvent refinement</u></b></a> <a href="/software/haddock2.2/waterref.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 In this section you can define if the final <a href="/software/haddock2.2/docking#water">explicit solvent refinement</a>
 should be performed (recommended since it does improve the docking solutions) and on how many structures. 
@@ -649,7 +649,7 @@ and the solvent molecules.
 <BR>
 <hr>
 <BR>
-<a name="scoring"><b>21. <u>Scoring</u></b></a> <a href="/software/haddock2.2/scoring.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="scoring"><b>21. <u>Scoring</u></b></a> <a href="/software/haddock2.2/scoring.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 In this section you can define individual weigths for the various terms using in scoring. This can be done separately  for the various docking stages (rigid body, semi-flexible refinement and explicit solvent refinement).
 You can also define the number of structures to analyze after the simulated annealing (it1) and
@@ -698,7 +698,7 @@ and <i>file.cns_all</i>) containing the original sorting of all structures will 
 <BR>
 <hr>
 <BR>
-<a name="anal"><b>22. <u>Analysis and clustering</u></b></a> <a href="/software/haddock2.2/analysis.png"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="anal"><b>22. <u>Analysis and clustering</u></b></a> <a href="/software/haddock2.2/analysis.png"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 When performing the <a href="/software/haddock2.2/analysis">analysis</a>, HADDOCK will check 
 <a href="/software/haddock2.2/analysis#hb">intermolecular hydrogen bonds</a> and <a href="/software/haddock2.2/analysis#nb">
@@ -740,7 +740,7 @@ amount of space.
 <BR>
 <hr>
 <BR>
-<a name="jobs"><b>25. <u>Parallels jobs</u></b></a> <a href="/software/haddock2.2/jobs.gif"><img src="http://wwww.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
+<a name="jobs"><b>25. <u>Parallels jobs</u></b></a> <a href="/software/haddock2.2/jobs.gif"><img src="http://www.bonvinlab.org/software/haddock2.2/camera.jpg" alt="(screenshot)"></a>
 <BR><BR>
 In this section you can define the way the structure calculation will be run, and the location
 of the <a href="http://cns.csb.yale.edu">CNS</a> executable. Currently 10 nodes or queues can

--- a/software/haddock2.2/start_new_help.html
+++ b/software/haddock2.2/start_new_help.html
@@ -17,8 +17,8 @@ image:
 <HR>
 
 Using your web browser, go to the 
-<A HREF="http://wwww.bonvinlab.org/software/haddock2.2">HADDOCK home-page</A>, 
-choose <A HREF="http://wwww.bonvinlab.org/software/haddock2.2/start-haddock">HADDOCK online</A> and click on <b>"Start a new project"</b>
+<A HREF="http://www.bonvinlab.org/software/haddock2.2">HADDOCK home-page</A>, 
+choose <A HREF="http://www.bonvinlab.org/software/haddock2.2/start-haddock">HADDOCK online</A> and click on <b>"Start a new project"</b>
 <BR>
 <HR>
 <BR>


### PR DESCRIPTION
HTML addresses typos (“wwww” instead of “www”) in:
- start_new_help.html
- run.html

All the other HTML files have been checked for this specific error, only these 2 files were concerned.