### PR TITLE
Corrected definition of effective distance calculation.

### DIFF
--- a/software/haddock2.2/generate_air_help.html
+++ b/software/haddock2.2/generate_air_help.html
@@ -80,7 +80,7 @@ Once you have defined your active and passive residues,
         distance entering the sum: 
         <br>
         <br>
-        <ul>d<sub>eff</sub>=[Sum(1/r<sup>6</sup>)]<sup>1/6</sup> </ul>
+        <ul>d<sub>eff</sub>=[Sum(1/r<sup>6</sup>)]<sup>-1/6</sup> </ul>
         <br>
         In addition since the degree of ambiguity is very high (several thousands distances can enter the sum), 
         the effective distance can be quite shorter than the shortest distance entering the sum!!!


### PR DESCRIPTION
Distance calculation was missing a minus on the exponent of the final sum.