### PR TITLE
updates disvis tutorial page

### DIFF
--- a/education/Others/disvis-webserver/index.md
+++ b/education/Others/disvis-webserver/index.md
@@ -208,7 +208,7 @@ This number can of course be changed when using the local version of DisVis.
 Once your job has completed, and provided you did not close the status page, you will be automatically redirected to the results
 page (you will also receive an email notification).
 
-If you don't' want to wait for your run to complete, you can access the precalculated results of a run submitted
+If you don't want to wait for your run to complete, you can access the precalculated results of a run submitted
 with the same input [here](https://wenmr.science.uu.nl/disvis/tutorial){:target="_blank"}.
 
 The results page presents a summary split into several sections:
@@ -246,16 +246,15 @@ their z-Score and their violation frequency for a specific number of restraints.
 crosslinks with the highest number of violations. The DisVis web server preformats the results in a way that false positive restraints
 are highlighted and can be spotted at a glance.
 
-In our case, you should observe that DisVis found solutions consistent with up to 6 restraints indicating that there might be three false positive restraints.Taking a closer look at the violations table might already be enough to determine which residues are most likely True false positives.
-In this example two restraints are violated in all complexes consistent with 6 restrains and are thus the most likely candidates:
+In our case, you should observe that DisVis found solutions consistent with up to 8 restraints indicating that there might be three false positive restraints.Taking a closer look at the violations table might already be enough to determine which residues are most likely True false positives.
+In this example one restraint is violated in all complexes consistent with 8 restrains and are thus the most likely candidates:
 
 <details style="background-color:#DAE4E7"><summary><b>See solution:</b>
 </summary>
 <center><b>A164(CA) - A49(CA)</b></center>
-<center><b>A49(CA) - A188(CA)</b></center>
 </details>
 
-When DisVis fails to identify complexes consistent with all provided restraints during quick scanning it is advisable to rerun with the complete scanning parameters before remove all restraints (or remove only the most violated ones and rerun with complete scanning). It is possible that a more thourough sampling of the interaction space will yield complexes consistent with all restraints or at least reduce the list of putative false positive restraints.  
+When DisVis fails to identify complexes consistent with all provided restraints during quick scanning it is advisable to rerun with the complete scanning parameters before remove all restraints (or remove only the most violated ones and rerun with complete scanning). It is possible that a more thorough sampling of the interaction space will yield complexes consistent with all restraints or at least reduce the list of putative false positive restraints.  
 
 ### DisVis output files
 
@@ -292,7 +291,7 @@ How many restraints do you need to significantly reduce the AIS? Can you explain
 
 <details style="background-color:#DAE4E7"><summary><b>See solution:</b>
 </summary><br>
-The most significant difference can be seen when going from <b>4</b> to <b>5</b> restraints. By looking closer at the restraints,
+The most significant difference can be seen when going from <b>3</b> to <b>4</b> restraints. By looking closer at the restraints,
 we can see that two clusters of 3 and 4 residues exist. Once we add a fifth restraint, links from both clusters need to be
 fulfilled. Thus, significantly reducing the accessible interaction space.
 </details>
@@ -366,12 +365,12 @@ __Note__ _that in the context of using this information to drive the docking in 
 
 <details style="background-color:#DAE4E7"><summary><b>See solution:</b>
 </summary><br>
-Respectively <b>11</b> and <b>8</b> residues have been identified as important for the interaction between <b>PRE5</b>
+Respectively <b>15</b> and <b>16</b> residues have been identified as important for the interaction between <b>PRE5</b>
 and <b>PUP2</b>:<br><br>
 
- PRE5 active residues: 7, 10, 13, 15, 55, 58, 60, 82, 83, 125, 126, 127, 128, 129, 131, 133 <br>
+ PRE5 active residues: 3, 5, 8, 11, 53, 54, 55,56, 58, 60, 79, 82 , 122, 123, 124
 
- PUP2 active residues: 1, 2, 3, 5, 8, 11, 13, 15, 16, 17, 114, 121, 122, 123, 124, 140, 152, 154, 177<br><br>
+ PUP2 active residues: 13, 15, 17, 18, 19, 126, 127, 128, 129, 130, 131, 162, 164, 165, 180, 184<br><br>
 
 
 You can see the results <a href="https://wenmr.science.uu.nl/disvis/tutorial/2" target="_blank" style="color:#294fa7">here</a>
@@ -499,16 +498,16 @@ extracted from *S.cerevisiae*.
 First select and colour the key residues identified by DisVis:
 
 <a class="prompt prompt-pymol">
-color red #0:7,10,13,15,55,58,60,82,83,125,126,127,128,129,131,133
+color red #0:3, 5, 8, 11, 53, 54, 55,56, 58, 60, 79, 82 , 122, 123, 124
 </a>
 <a class="prompt prompt-pymol">
-color orange #1:1,2,3,5,8,11,13,15,16,17,114,121,122,123,124,140,152,154,177
+color orange #1:13, 15, 17, 18, 19, 126, 127, 128, 129, 130, 131, 162, 164, 165, 180, 184
 </a>
 <a class="prompt prompt-pymol">
-show #0:7,10,13,15,55,58,60,82,83,125,126,127,128,129,131,133
+show #0:3, 5, 8, 11, 53, 54, 55,56, 58, 60, 79, 82 , 122, 123, 124
 </a>
 <a class="prompt prompt-pymol">
-show #1:1,2,3,5,8,11,13,15,16,17,114,121,122,123,124,140,152,154,177
+show #1:13, 15, 17, 18, 19, 126, 127, 128, 129, 130, 131, 162, 164, 165, 180, 184
 </a>
 
 <details style="background-color:#DAE4E7">


### PR DESCRIPTION
This PR corrects DisVis tutorial regarding the swapping of the structure names (PRE5 and PUP2). This change does not affect the overall message of the tutorial, but it improves the detailed results.

**The problem:** `PRE5.pdb` and `PUP2.pdb` file names are swapped in the original data.

**What I did to correct the tutorial:**

1. When downloading the `disvis-tutorial.tgz`file and inspecting the PDB files in detail we see that the `PRE5.pdb` contains the sequence of  PUP2 (UniProtKB: [Q9UT97](http://www.uniprot.org/uniprot/Q9UT97)) and `PUP2.pdb` contains the sequence of PRE5 (UniProtKB: [O14250](http://www.uniprot.org/uniprot/O14250)).
1. I swapped name of PDB files
1. I changed the new PRE5.pdb chain B to A and new PUP2.pdb chain A  to B. In this way the pdbs are in agreement with the chains in `restraints.txt`. I used:
   1. `pdb_chain -A PRE5.pdb > pre5.pdb`
   1. `pdb_chain -B PUP2.pdb > pup2.pdb`
   1. `mv pub2.pdb PUB2.pdb`
   1. `mv pre5.pdb PRE5.pdb`
   1. new files can be downloaded here: https://transfer.sh/jwefzD/new_structures.zip
1. open them in chimera first PRE5 than PUP2 (as said in the tutorial)
1. Sent the first tutorial run with these settings: https://wenmr.science.uu.nl/disvis/run/kwO_3K3%2BbmqJ
1. after the run we see that the Number of accessible complexes 0 for 9 restraints, while it was 0 for 7 restraints in the original version
1. False positives, with the corrected version we find:
     1. A164-B49 (2.38) -> original version was 1.45
     1. A49-B188 (0.48) -> original version was 1.23
1. identified false positives as restraint 5: "A 164 CA B  49 CA 0 23". Before the false positive was ambiguous. (restraint 3 (0.85), 5, and 9), where 3 is in the interface when visualised in the corrected structures.
1. Question: "Using the different descriptions of the sections we provided above together with the information on the results page of your run, what are likely false positive restraints according to DisVis?"
   1. here i answered only restraint 5, but maybe A49-B188 can also be considered even with z-score 0.48 because it is the second highest
1. the N threshold is 3 to 4 when visualising `accessible_interaction_space.mrc`.
1. removed only restraint 5 to generate a new `restraints_filtered.txt`. But maybe we could remove also restraint 9.
1. swapped lines in `accessible_res_70.list`
1. did the complete scanning also with occupancy analysis: submitted second job: https://wenmr.science.uu.nl/disvis/run/kwO_3K4aijxJ
1. the number of restraints in the Interaction Analysis table is 8 instead of 7. Identified residues above 0.5:
   1. PRE5 (new): 3, 5, 8, 11, 53, 54, 55,56, 58, 60, 79, 82 , 122, 123, 124
   1. PUP2 (new): 13, 15, 17, 18, 19, 126, 127, 128, 129, 130, 131, 162, 164, 165, 180, 184,
1. Following the description of `5L5A` we can see that the original input structured were really swapped as the original tutorial says `5L5A` chain `D` corresponds to `PRE5` and this is still true even after the PDBs names are changed.
1. Made some chimera sessions to show the distances, and the interactions. They can be downloaded here: https://transfer.sh/BKsQPu/chimera_sessions.zip
1. We can see in the corrected example there is no "alone Leucine" as in the original tutorial.

If you agree with this, I need help in defining which files go in the `disvis_tutorial.tgz`, namely the `second_run_with_mrc.py`, and the `results` folder. I haven't investigated yet if this branches to other tutorial pages.