### PR TITLE
Corrects `lig2shape`

### DIFF
--- a/education/HADDOCK24/shape-small-molecule/scripts/lig2shape.py
+++ b/education/HADDOCK24/shape-small-molecule/scripts/lig2shape.py
@@ -28,7 +28,7 @@ def format_shape_pharm(lig):
         x = float(line[atom_x])
         y = float(line[atom_y])
         z = float(line[atom_z])
-        pharm_info = float(line[atom_temp])
+        pharm_info = float(line[atom_occ])
         print("ATOM   {: >4d}  SHA SHA S{: >4d}     {: 7.3f} {: 7.3f} {: 7.3f} {:5.2f}  1.00 ".format(resi, resi, x, y, z, pharm_info))
     print("END")
     ligFile.close()

--- a/education/HADDOCK24/shape-small-molecule/scripts/lig2shape.py
+++ b/education/HADDOCK24/shape-small-molecule/scripts/lig2shape.py
@@ -1,32 +1,55 @@
 import sys
 
+# slice objects for the different PDB v3 columns
+atom_record = slice(0, 6)
+atom_serial = slice(6, 11)
+atom_name = slice(12, 16)
+atom_altLoc = slice(16, 17)
+atom_resName = slice(17, 20)
+atom_chainID = slice(21, 22)
+atom_resSeq = slice(22, 26)
+atom_iCode = slice(26, 27)
+atom_x = slice(30, 38)
+atom_y = slice(38, 46)
+atom_z = slice(46, 54)
+atom_occ = slice(54, 60)
+atom_temp = slice(60, 66)
+atom_segid = slice(72, 76)
+atom_element = slice(76, 78)
+atom_model = slice(78, 80)
+
+
 def format_shape_pharm(lig):
     ligFile = open(lig, 'r')
 
-    for line in ligFile:
-        if 'HETATM' in line or 'ATOM' in line:
-            resi = int(line.split( )[1])
-            x = float(line.split( )[6])
-            y = float(line.split( )[7])
-            z = float(line.split( )[8])
-            pharm_info = float(line.split( )[9])
-            print("ATOM   {: >4d}  SHA SHA S{: >4d}     {: 7.3f} {: 7.3f} {: 7.3f} {:5.2f}  1.00 ".format(resi, resi, x, y, z, pharm_info))
+    atom_lines = (l for l in ligFile if l.startswith(("HETATM", "ATOM")))
+    for line in atom_lines:
+        resi = int(line[atom_serial])
+        x = float(line[atom_x])
+        y = float(line[atom_y])
+        z = float(line[atom_z])
+        pharm_info = float(line[atom_temp])
+        print("ATOM   {: >4d}  SHA SHA S{: >4d}     {: 7.3f} {: 7.3f} {: 7.3f} {:5.2f}  1.00 ".format(resi, resi, x, y, z, pharm_info))
     print("END")
+    ligFile.close()
 
 
 def format_shape(lig):
     ligFile = open(lig, 'r')
 
-    for line in ligFile:
-        if 'HETATM' in line or 'ATOM' in line:
-            resi = int(line.split( )[1])
-            x = float(line.split( )[6])
-            y = float(line.split( )[7])
-            z = float(line.split( )[8])
-            print("ATOM   {: >4d}  SHA SHA S{: >4d}     {: 7.3f} {: 7.3f} {: 7.3f}  1.00  1.00 ".format(resi, resi, x, y, z))
+    atom_lines = (l for l in ligFile if l.startswith(("HETATM", "ATOM")))
+    for line in atom_lines:
+        resi = int(line[atom_serial])
+        x = float(line[atom_x])
+        y = float(line[atom_y])
+        z = float(line[atom_z])
+        print("ATOM   {: >4d}  SHA SHA S{: >4d}     {: 7.3f} {: 7.3f} {: 7.3f}  1.00  1.00 ".format(resi, resi, x, y, z))
     print("END")
-    
+    ligFile.close()
+
+
 if __name__ == "__main__":
+
     mode = sys.argv[1]
     lig = sys.argv[2]
 
@@ -35,4 +58,3 @@ if __name__ == "__main__":
 
     if mode == "pharm":
         format_shape_pharm(lig)
-        


### PR DESCRIPTION
Corrects `lig2shape` to use PDB v3 column indexes.
From what understood from the example:
`python ./scripts/lig2shape.py shape/pharm VU7.pdb`
The `pharm` option should report on the `occupancy` column. Is that it?
