### PR TITLE
update jquery version

### DIFF
--- a/_includes/_scripts.html
+++ b/_includes/_scripts.html
@@ -1,5 +1,5 @@
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="{{ site.url }}/assets/js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/3.5.0/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="{{ site.url }}/assets/js/vendor/jquery-3.5.0.min.js"><\/script>')</script>
 <script src="{{ site.url }}/assets/js/scripts.min.js"></script>
 {% if site.owner.google.analytics %}
 <!-- Asynchronous Google Analytics snippet -->


### PR DESCRIPTION
This PR updates the jquery version from 1.9.1 to 3.5.0 - the version it was using was 10 years old 🧓🏽 

I see multiple re-loads of jquery in specific pages such as `covid_ace2_unambig.html`, `covid_dhfr_unambig.html`, `covid_mpro_tanimoto.html` and `covid_rdrp_unambig.html` poiting to v3.5.0 - probably to overwrite old version 1.9.1

This also fixes https://github.com/haddocking/haddocking.github.io/security/dependabot/1