### PR TITLE
add action to check if the site is buildable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: check if site is buildable
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1.0.9
+        with:
+          source: ./
+          destination: ./_site


### PR DESCRIPTION
This PR adds `build.yml` which is an action to check if the website is buildable - currently this is only done during the website deployment. Checking this in the PR should avoid surprises